### PR TITLE
Creation of dimension full_tree_nodes that is a concatenation of nodes from top (theme) to end (Node_ID), in themes and asset_themes to support content analysis

### DIFF
--- a/Views/asset_themes.view.lkml
+++ b/Views/asset_themes.view.lkml
@@ -86,6 +86,13 @@ view: asset_themes {
     sql: ${TABLE}.asset_subsubtopic ;;
   }
 
+  dimension: full_tree_nodes {
+    label: "Full Tree Nodes"
+    type:  string
+    sql:  ${TABLE}.full_tree_nodes ;;
+    description: "List of nodes from Theme to NodeID "
+  }
+
   measure: count {
     type: count
     drill_fields: [asset_subtheme_id, asset_subtheme_id, google_pdt.count, asset_themes.count]

--- a/Views/metadata.view.lkml
+++ b/Views/metadata.view.lkml
@@ -58,6 +58,7 @@ view: metadata {
   dimension: lineage_nodes{
     type:  string
     sql: CONCAT(${TABLE}.ancestor_nodes,concat('|',concat(${TABLE}.parent_node_id,concat('|',${TABLE}.node_id)))) ;;
+    description: "The combination of all the nodes from top level to the node_id."
   }
 
   dimension_group: modified {

--- a/Views/metadata.view.lkml
+++ b/Views/metadata.view.lkml
@@ -55,6 +55,11 @@ view: metadata {
     sql: ${TABLE}.language_name ;;
   }
 
+  dimension: lineage_nodes{
+    type:  string
+    sql: CONCAT(${TABLE}.ancestor_nodes,concat('|',concat(${TABLE}.parent_node_id,concat('|',${TABLE}.node_id)))) ;;
+  }
+
   dimension_group: modified {
     type: time
     timeframes: [

--- a/Views/metadata.view.lkml
+++ b/Views/metadata.view.lkml
@@ -55,12 +55,6 @@ view: metadata {
     sql: ${TABLE}.language_name ;;
   }
 
-  dimension: lineage_nodes{
-    type:  string
-    sql: CONCAT(${TABLE}.ancestor_nodes,concat('|',concat(${TABLE}.parent_node_id,concat('|',${TABLE}.node_id)))) ;;
-    description: "The combination of all the nodes from top level to the node_id."
-  }
-
   dimension_group: modified {
     type: time
     timeframes: [

--- a/Views/themes.view.lkml
+++ b/Views/themes.view.lkml
@@ -88,8 +88,12 @@ view: themes {
     group_label: "BC Bid Dimensions"
   }
 
-
-
+  dimension: full_tree_nodes {
+    label: "Full Tree Nodes"
+    type:  string
+    sql:  ${TABLE}.full_tree_nodes ;;
+    description: "List of nodes from Theme to NodeID "
+  }
 
   dimension: topic_id {
     description: "The alphanumeric CMS Lite topic identifier."


### PR DESCRIPTION
This PR is to create the dimension "lineage_nodes" that is a concatenation of ancestor_nodes, parent_node_id and node_id with "|" in between the variables.

This addition of a dimension should not impact existing functionality as no dimensions were renamed or deleted.